### PR TITLE
Backport security fixes from upstream 1.24 branch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+gst-plugins-ugly1.0 (1.24.6-1deepin1) unstable; urgency=medium
+
+  * Backport security fixes from upstream 1.24 branch:
+    - d/patches/0001-asfdemux-Error-out-on-files-with-more-than-32-stream.patch
+    - d/patches/0002-rmdemux-Check-if-new-video-fragment-overflows-the-fr.patch
+    - d/patches/0003-rmdemux-Avoid-integer-overflow-when-checking-if-enou.patch
+    fixing: CVE-2026-2920, CVE-2026-2922
+
+ -- Tianyu Chen <sweetyfish@deepin.org>  Mon, 23 Mar 2026 18:22:03 +0800
+
 gst-plugins-ugly1.0 (1.24.6-1) unstable; urgency=medium
 
   * New upstream version 1.24.6

--- a/debian/patches/0001-asfdemux-Error-out-on-files-with-more-than-32-stream.patch
+++ b/debian/patches/0001-asfdemux-Error-out-on-files-with-more-than-32-stream.patch
@@ -1,0 +1,56 @@
+From: =?utf-8?q?Sebastian_Dr=C3=B6ge?= <sebastian@centricular.com>
+Date: Wed, 11 Feb 2026 19:27:09 +0200
+Subject: asfdemux: Error out on files with more than 32 streams
+
+This avoids overflowing the static streams array and overwriting
+random other element state.
+
+Fixes GST--SA-2026-0006, CVE-2026-2920, ZDI-CAN-28843.
+
+Fixes https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/4900
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/10942>
+---
+ gst/asfdemux/gstasfdemux.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/gst/asfdemux/gstasfdemux.c b/gst/asfdemux/gstasfdemux.c
+index 3a6bc9a..7de9aac 100644
+--- a/gst/asfdemux/gstasfdemux.c
++++ b/gst/asfdemux/gstasfdemux.c
+@@ -2616,6 +2616,9 @@ gst_asf_demux_setup_pad (GstASFDemux * demux, GstPad * src_pad,
+ {
+   AsfStream *stream;
+ 
++  /* Checked in the callers */
++  g_assert (demux->num_streams < G_N_ELEMENTS (demux->stream));
++
+   gst_pad_use_fixed_caps (src_pad);
+   gst_pad_set_caps (src_pad, caps);
+ 
+@@ -3071,6 +3074,12 @@ gst_asf_demux_parse_stream_object (GstASFDemux * demux, guint8 * data,
+     case ASF_STREAM_AUDIO:{
+       asf_stream_audio audio_object;
+ 
++      if (demux->num_streams >= G_N_ELEMENTS (demux->stream)) {
++        GST_ELEMENT_ERROR (demux, STREAM, DEMUX, (NULL),
++            ("File has too many streams"));
++        return NULL;
++      }
++
+       if (!gst_asf_demux_get_stream_audio (&audio_object, &data, &size))
+         goto not_enough_data;
+ 
+@@ -3149,6 +3158,12 @@ gst_asf_demux_parse_stream_object (GstASFDemux * demux, guint8 * data,
+       asf_stream_video video_object;
+       guint16 vsize;
+ 
++      if (demux->num_streams >= G_N_ELEMENTS (demux->stream)) {
++        GST_ELEMENT_ERROR (demux, STREAM, DEMUX, (NULL),
++            ("File has too many streams"));
++        return NULL;
++      }
++
+       if (!gst_asf_demux_get_stream_video (&video_object, &data, &size))
+         goto not_enough_data;
+ 

--- a/debian/patches/0002-rmdemux-Check-if-new-video-fragment-overflows-the-fr.patch
+++ b/debian/patches/0002-rmdemux-Check-if-new-video-fragment-overflows-the-fr.patch
@@ -1,0 +1,42 @@
+From: =?utf-8?q?Sebastian_Dr=C3=B6ge?= <sebastian@centricular.com>
+Date: Wed, 11 Feb 2026 19:58:31 +0200
+Subject: rmdemux: Check if new video fragment overflows the fragment storage
+ before storing it
+
+There already was a check but that happened afterwards, i.e. after an
+out-of-bounds write that overwrote some following struct data.
+
+Fixes GST-SA-2026-0005, CVE-2026-2922, ZDI-CAN-28845.
+
+Fixes https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/4905
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/10944>
+---
+ gst/realmedia/rmdemux.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/gst/realmedia/rmdemux.c b/gst/realmedia/rmdemux.c
+index 9819326..521d471 100644
+--- a/gst/realmedia/rmdemux.c
++++ b/gst/realmedia/rmdemux.c
+@@ -2369,15 +2369,17 @@ gst_rmdemux_parse_video_packet (GstRMDemux * rmdemux, GstRMDemuxStream * stream,
+       stream->frag_length = fragment_size;
+     }
+ 
++    if (stream->frag_count >= MAX_FRAGS) {
++      gst_buffer_unref (fragment);
++      goto too_many_fragments;
++    }
++
+     /* put fragment in adapter */
+     gst_adapter_push (stream->adapter, fragment);
+     stream->frag_offset[stream->frag_count] = stream->frag_current;
+     stream->frag_current += fragment_size;
+     stream->frag_count++;
+ 
+-    if (stream->frag_count > MAX_FRAGS)
+-      goto too_many_fragments;
+-
+     GST_DEBUG_OBJECT (rmdemux, "stored fragment in adapter %d/%d",
+         stream->frag_current, stream->frag_length);
+ 

--- a/debian/patches/0003-rmdemux-Avoid-integer-overflow-when-checking-if-enou.patch
+++ b/debian/patches/0003-rmdemux-Avoid-integer-overflow-when-checking-if-enou.patch
@@ -1,0 +1,24 @@
+From: =?utf-8?q?Sebastian_Dr=C3=B6ge?= <sebastian@centricular.com>
+Date: Wed, 11 Feb 2026 20:00:04 +0200
+Subject: rmdemux: Avoid integer overflow when checking if enough data is
+ available for video fragment
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/10944>
+---
+ gst/realmedia/rmdemux.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/gst/realmedia/rmdemux.c b/gst/realmedia/rmdemux.c
+index 521d471..19beb51 100644
+--- a/gst/realmedia/rmdemux.c
++++ b/gst/realmedia/rmdemux.c
+@@ -2348,7 +2348,8 @@ gst_rmdemux_parse_video_packet (GstRMDemux * rmdemux, GstRMDemuxStream * stream,
+     }
+     GST_DEBUG_OBJECT (rmdemux, "fragment size %d", fragment_size);
+ 
+-    if (map.size < (data - map.data) + fragment_size)
++    if (fragment_size > map.size
++        || (data - map.data) > map.size - fragment_size)
+       goto not_enough_data;
+ 
+     /* get the fragment */

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,3 @@
+0001-asfdemux-Error-out-on-files-with-more-than-32-stream.patch
+0002-rmdemux-Check-if-new-video-fragment-overflows-the-fr.patch
+0003-rmdemux-Avoid-integer-overflow-when-checking-if-enou.patch


### PR DESCRIPTION
- d/patches/0001-asfdemux-Error-out-on-files-with-more-than-32-stream.patch
- d/patches/0002-rmdemux-Check-if-new-video-fragment-overflows-the-fr.patch
- d/patches/0003-rmdemux-Avoid-integer-overflow-when-checking-if-enou.patch
Fixing: CVE-2026-2920, CVE-2026-2922
